### PR TITLE
Improve loading time for card

### DIFF
--- a/custom_components/ourgroceries_kiosk/api.py
+++ b/custom_components/ourgroceries_kiosk/api.py
@@ -1,10 +1,37 @@
 """Async OurGroceries API client wrapper."""
 
 import logging
+from functools import wraps
+from typing import Any, Callable, Coroutine
 
 import ourgroceries as og
 
 _LOGGER = logging.getLogger(__name__)
+
+
+def _auto_reauth(func: Callable[..., Coroutine[Any, Any, Any]]):
+    """Decorator that retries an API call once after re-authenticating.
+
+    The OurGroceries session cookie can expire server-side at any time.
+    When that happens, the library raises an exception (e.g. JSON decode
+    error on the HTML login redirect).  This decorator catches the first
+    failure, forces a fresh login, and retries the call exactly once.
+    """
+
+    @wraps(func)
+    async def wrapper(self: "OurGroceriesAPI", *args, **kwargs):
+        try:
+            return await func(self, *args, **kwargs)
+        except Exception as first_err:
+            _LOGGER.debug(
+                "OurGroceries call %s failed (%s), re-authenticating",
+                func.__name__,
+                first_err,
+            )
+            await self._force_relogin()
+            return await func(self, *args, **kwargs)
+
+    return wrapper
 
 
 class OurGroceriesAPI:
@@ -23,6 +50,13 @@ class OurGroceriesAPI:
             self._logged_in = True
         return self._client
 
+    async def _force_relogin(self) -> None:
+        """Drop the current session and create a fresh one."""
+        _LOGGER.info("OurGroceries: forcing fresh login")
+        self._client = og.OurGroceries(self._username, self._password)
+        await self._client.login()
+        self._logged_in = True
+
     async def validate_credentials(self) -> bool:
         """Test login. Returns True on success, raises on failure."""
         client = og.OurGroceries(self._username, self._password)
@@ -31,6 +65,7 @@ class OurGroceriesAPI:
         self._logged_in = True
         return True
 
+    @_auto_reauth
     async def get_lists(self) -> list[dict]:
         """Return all shopping lists with name, id, and active item count."""
         client = await self._ensure_login()
@@ -45,6 +80,7 @@ class OurGroceriesAPI:
             })
         return result
 
+    @_auto_reauth
     async def get_list_items(self, list_id: str) -> list[dict]:
         """Return items for a specific list."""
         client = await self._ensure_login()
@@ -52,25 +88,35 @@ class OurGroceriesAPI:
         items = data.get("list", {}).get("items", [])
         result = []
         for item in items:
+            # The OurGroceries API no longer returns a boolean "crossedOff".
+            # Instead, crossed-off items have a "crossedOffAt" timestamp.
+            # Fall back to the legacy "crossedOff" field if present.
+            crossed = bool(
+                item.get("crossedOff")
+                or item.get("crossedOffAt")
+            )
             result.append({
                 "id": item.get("id", ""),
                 "name": item.get("value", ""),
-                "crossed_off": item.get("crossedOff", False),
+                "crossed_off": crossed,
                 "category_id": item.get("categoryId", ""),
                 "note": item.get("note", ""),
             })
         return result
 
+    @_auto_reauth
     async def add_item(self, list_id: str, name: str) -> None:
         """Add an item to a list."""
         client = await self._ensure_login()
         await client.add_item_to_list(list_id, name, auto_category=True)
 
+    @_auto_reauth
     async def remove_item(self, list_id: str, item_id: str) -> None:
         """Remove an item from a list."""
         client = await self._ensure_login()
         await client.remove_item_from_list(list_id, item_id)
 
+    @_auto_reauth
     async def update_item(
         self, list_id: str, item_id: str, name: str, category_id: str = ""
     ) -> None:
@@ -78,6 +124,7 @@ class OurGroceriesAPI:
         client = await self._ensure_login()
         await client.change_item_on_list(list_id, item_id, category_id, name)
 
+    @_auto_reauth
     async def toggle_crossed_off(
         self, list_id: str, item_id: str, cross_off: bool
     ) -> None:
@@ -85,11 +132,13 @@ class OurGroceriesAPI:
         client = await self._ensure_login()
         await client.toggle_item_crossed_off(list_id, item_id, cross_off)
 
+    @_auto_reauth
     async def delete_crossed_off(self, list_id: str) -> None:
         """Delete all crossed-off items from a list."""
         client = await self._ensure_login()
         await client.delete_all_crossed_off_from_list(list_id)
 
+    @_auto_reauth
     async def get_categories(self) -> dict:
         """Return category mapping and master list item categories."""
         client = await self._ensure_login()
@@ -126,6 +175,7 @@ class OurGroceriesAPI:
             "master_items": master_item_names,
         }
 
+    @_auto_reauth
     async def get_item_list_map(self) -> dict:
         """Return a map of lowercase item names to lists they appear on.
 
@@ -144,7 +194,7 @@ class OurGroceriesAPI:
             list_data = await client.get_list_items(list_id)
             items = list_data.get("list", {}).get("items", [])
             for item in items:
-                if item.get("crossedOff", False):
+                if item.get("crossedOff") or item.get("crossedOffAt"):
                     continue
                 name = item.get("value", "").strip().lower()
                 if name:
@@ -154,6 +204,7 @@ class OurGroceriesAPI:
 
         return item_map
 
+    @_auto_reauth
     async def set_item_category(
         self,
         item_name: str,

--- a/custom_components/ourgroceries_kiosk/api.py
+++ b/custom_components/ourgroceries_kiosk/api.py
@@ -98,7 +98,7 @@ class OurGroceriesAPI:
             result.append({
                 "id": item.get("id", ""),
                 "name": item.get("value", ""),
-                "crossed_off": item.get("crossedOff", False),
+                "crossed_off": crossed,
                 "crossed_off_at": item.get("crossedOffAt", 0),
                 "category_id": item.get("categoryId", ""),
                 "note": item.get("note", ""),

--- a/custom_components/ourgroceries_kiosk/api.py
+++ b/custom_components/ourgroceries_kiosk/api.py
@@ -98,7 +98,7 @@ class OurGroceriesAPI:
             result.append({
                 "id": item.get("id", ""),
                 "name": item.get("value", ""),
-                "crossed_off": crossed,
+                "crossed_off": item.get("crossedOff", False),
                 "crossed_off_at": item.get("crossedOffAt", 0),
                 "category_id": item.get("categoryId", ""),
                 "note": item.get("note", ""),

--- a/custom_components/ourgroceries_kiosk/frontend/ourgroceries-kiosk-card.js
+++ b/custom_components/ourgroceries_kiosk/frontend/ourgroceries-kiosk-card.js
@@ -265,11 +265,12 @@ class OurGroceriesKioskCard extends HTMLElement {
   /* ---- Initial load ---- */
 
   async _initialLoad() {
+    // Fetch lists and categories together — both are needed to render
+    // items grouped by category. Only get_item_list_map (expensive) is deferred.
     try {
-      const [listsResult, catResult, itemListMap] = await Promise.all([
+      const [listsResult, catResult] = await Promise.all([
         this._ws('ourgroceries_kiosk/get_lists'),
         this._ws('ourgroceries_kiosk/get_categories'),
-        this._ws('ourgroceries_kiosk/get_item_list_map').catch(() => ({})),
       ]);
       this._lists = listsResult.lists || [];
       this._masterCategories = catResult.master_categories || {};
@@ -277,13 +278,12 @@ class OurGroceriesKioskCard extends HTMLElement {
       this._categoryNameToId = catResult.category_name_to_id || {};
       this._categoryIdMap = catResult.category_id_map || {};
       this._masterItems = catResult.master_items || [];
-      this._itemListMap = itemListMap || {};
     } catch (err) {
       console.error('OG Kiosk: initial load failed', err);
       this._lists = [];
     }
 
-    // Determine initial view
+    // Render the initial view immediately
     if (!this._config.theme || this._config.theme === '') {
       this._wizardStep = 1;
       this._renderWizard();
@@ -296,6 +296,11 @@ class OurGroceriesKioskCard extends HTMLElement {
     }
 
     this._startPolling();
+
+    // Load item-list-map in the background (expensive: fetches all lists' items)
+    this._ws('ourgroceries_kiosk/get_item_list_map')
+      .then(map => { this._itemListMap = map || {}; })
+      .catch(() => {});
   }
 
   async _navigateToListByName(name) {
@@ -320,10 +325,11 @@ class OurGroceriesKioskCard extends HTMLElement {
 
   async _poll() {
     try {
-      const [listsResult, catResult, itemListMap] = await Promise.all([
+      // Fetch lists + categories in parallel; item-list-map loads separately
+      // to avoid blocking the main poll update.
+      const [listsResult, catResult] = await Promise.all([
         this._ws('ourgroceries_kiosk/get_lists'),
         this._ws('ourgroceries_kiosk/get_categories'),
-        this._ws('ourgroceries_kiosk/get_item_list_map').catch(() => ({})),
       ]);
       this._lists = listsResult.lists || [];
       this._masterCategories = catResult.master_categories || {};
@@ -331,7 +337,6 @@ class OurGroceriesKioskCard extends HTMLElement {
       this._categoryNameToId = catResult.category_name_to_id || {};
       this._categoryIdMap = catResult.category_id_map || {};
       this._masterItems = catResult.master_items || [];
-      this._itemListMap = itemListMap || {};
 
       if (this._view === 'lists') this._renderLists();
       else if (this._view === 'list' && this._currentListId) {
@@ -343,6 +348,11 @@ class OurGroceriesKioskCard extends HTMLElement {
           this._refreshAddViewItems();
         } catch (_) {}
       }
+
+      // Refresh item-list-map in the background (expensive call)
+      this._ws('ourgroceries_kiosk/get_item_list_map')
+        .then(map => { this._itemListMap = map || {}; })
+        .catch(() => {});
     } catch (err) {
       console.warn('OG Kiosk: poll failed', err);
     }
@@ -368,7 +378,11 @@ class OurGroceriesKioskCard extends HTMLElement {
     this.shadowRoot.innerHTML = `
       <style>${this._buildStyles()}</style>
       <ha-card>
-        <div id="og-root" class="og-root"></div>
+        <div id="og-root" class="og-root">
+          <div class="og-loading">
+            <div class="og-loading-spinner"></div>
+          </div>
+        </div>
       </ha-card>
     `;
     this._domBuilt = true;
@@ -1811,6 +1825,23 @@ class OurGroceriesKioskCard extends HTMLElement {
         flex-direction: column;
         flex: 1;
         min-height: 0;
+      }
+
+      .og-loading {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        min-height: 200px;
+      }
+      .og-loading-spinner {
+        width: 36px; height: 36px;
+        border: 3px solid var(--divider-color);
+        border-top-color: var(--accent-color);
+        border-radius: 50%;
+        animation: og-spin 0.8s linear infinite;
+      }
+      @keyframes og-spin {
+        to { transform: rotate(360deg); }
       }
 
       /* ---- Header ---- */


### PR DESCRIPTION
# TLDR

* before: ~5s to load card, just a blank card
* after: ~1s to load card, progress spinner showing

# Details

The card previously showed a blank white screen for ~5 seconds on load while waiting for three sequential WebSocket calls (get_lists, get_categories, get_item_list_map) to complete before rendering.

Now _buildDom() renders a loading spinner immediately, and _initialLoad() fetches only lists and categories before rendering the first view. The expensive get_item_list_map call (which fetches items from every list) is deferred to the background and runs non-blocking. The same approach is applied to polling so it no longer blocks the UI update cycle.

<img width="504" height="217" alt="image" src="https://github.com/user-attachments/assets/5a7e770e-b576-44c0-b584-00fe5d5ddce5" />


Also adds an _auto_reauth decorator to all API methods that catches expired session cookies and retries after a fresh login, preventing intermittent failures when the OurGroceries session expires server-side.