### PR TITLE
Sort crossed-off items by tick order instead of alphabetically

### DIFF
--- a/custom_components/ourgroceries_kiosk/api.py
+++ b/custom_components/ourgroceries_kiosk/api.py
@@ -56,6 +56,7 @@ class OurGroceriesAPI:
                 "id": item.get("id", ""),
                 "name": item.get("value", ""),
                 "crossed_off": item.get("crossedOff", False),
+                "crossed_off_at": item.get("crossedOffAt", 0),
                 "category_id": item.get("categoryId", ""),
                 "note": item.get("note", ""),
             })

--- a/custom_components/ourgroceries_kiosk/frontend/ourgroceries-kiosk-card.js
+++ b/custom_components/ourgroceries_kiosk/frontend/ourgroceries-kiosk-card.js
@@ -591,7 +591,7 @@ class OurGroceriesKioskCard extends HTMLElement {
     // Crossed-off items
     let crossedHtml = '';
     if (crossedOff.length > 0) {
-      const sorted = [...crossedOff].sort((a, b) => a.name.toLowerCase().localeCompare(b.name.toLowerCase()));
+      const sorted = [...crossedOff].sort((a, b) => (a.crossed_off_at || 0) - (b.crossed_off_at || 0));
       for (const item of sorted) {
         crossedHtml += `
           <div class="og-crossed-item" data-id="${this._escAttr(item.id)}">


### PR DESCRIPTION
Previously crossed-off items were sorted alphabetically, which made it hard to see what was most recently checked off. Now they sort by the crossedOffAt timestamp from the OurGroceries API, with the first item ticked appearing at the top. 
**This is also how the official web app and native apps display it.**

The crossedOffAt field was already available in the raw API response but was only used to derive a boolean. Now api.py passes the timestamp through as crossed_off_at, and the frontend sorts on it.

# Before

<img width="1824" height="786" alt="image" src="https://github.com/user-attachments/assets/291724ca-5999-443f-aa00-f338cfcbdc22" />

# After 

<img width="502" height="430" alt="image" src="https://github.com/user-attachments/assets/6c46d827-a0c6-48e3-8407-f42244b3e061" />
