### PR TITLE
Sort add-item list by server-tracked usage frequency (addedCount)

### DIFF
--- a/custom_components/ourgroceries_kiosk/api.py
+++ b/custom_components/ourgroceries_kiosk/api.py
@@ -113,7 +113,7 @@ class OurGroceriesAPI:
                     master_categories[name] = cat_map[cat_id]
 
         master_item_names = [
-            item.get("value", "")
+            {"name": item.get("value", ""), "added_count": item.get("addedCount", 0)}
             for item in master_items
             if item.get("value", "").strip()
         ]

--- a/custom_components/ourgroceries_kiosk/frontend/ourgroceries-kiosk-card.js
+++ b/custom_components/ourgroceries_kiosk/frontend/ourgroceries-kiosk-card.js
@@ -790,15 +790,18 @@ class OurGroceriesKioskCard extends HTMLElement {
     );
     const seen = new Set();
     const allItems = [];
-    for (const name of this._masterItems) {
+    for (const mi of this._masterItems) {
+      const name = typeof mi === 'string' ? mi : mi.name;
       const key = name.trim().toLowerCase();
       if (key && !seen.has(key)) {
         seen.add(key);
-        allItems.push(name.trim());
+        allItems.push({ name: name.trim(), addedCount: (mi && mi.added_count) || 0 });
       }
     }
+    allItems.sort((a, b) => b.addedCount - a.addedCount);
     let html = '';
-    for (const name of allItems) {
+    for (const entry of allItems) {
+      const name = entry.name;
       const key = name.toLowerCase();
       const lists = this._itemListMap[key] || [];
       let subtitle = '';
@@ -1688,7 +1691,8 @@ class OurGroceriesKioskCard extends HTMLElement {
       if (!item.crossed_off) addEntry(this._parseQuantity(item.name.trim()).baseName);
     }
     // Master items in server frequency order (most commonly added first)
-    for (const name of this._masterItems) {
+    for (const mi of this._masterItems) {
+      const name = typeof mi === 'string' ? mi : mi.name;
       const key = name.trim().toLowerCase();
       addEntry(historyDisplay[key] || this._titleCase(key));
     }


### PR DESCRIPTION
The add-item view previously displayed master list items in arbitrary server order, making frequently used items hard to find. The OurGroceries API returns an addedCount field on each master list item tracking how many times it has been added across all lists.

Now api.py passes addedCount through as added_count, and the frontend sorts the add-item list by descending count so the most commonly purchased items appear first. 
**This is also how the official web app and native apps display it.**

# Before

<img width="499" height="480" alt="image" src="https://github.com/user-attachments/assets/2ecea96a-f89c-4fad-9c74-6c3356dacf70" />

# After

<img width="498" height="358" alt="image" src="https://github.com/user-attachments/assets/3b904c7f-fc48-49fa-a792-aef8e489af65" />


# How it looks on official web app

<img width="565" height="611" alt="image" src="https://github.com/user-attachments/assets/126303d3-00c7-445e-8c6d-779e862b20d5" />
