### PR TITLE
feat(compact): add missing compact density styles

### DIFF
--- a/custom_components/ourgroceries_kiosk/frontend/ourgroceries-kiosk-card.js
+++ b/custom_components/ourgroceries_kiosk/frontend/ourgroceries-kiosk-card.js
@@ -2452,6 +2452,11 @@ class OurGroceriesKioskCard extends HTMLElement {
       :host(.og-compact) .og-crossed-name { font-size: 14px; }
       :host(.og-compact) .og-category-bar { padding-block: 2px; font-size: 14px; }
       :host(.og-compact) .og-list-row { padding: 10px 20px; font-size: 17px; }
+      :host(.og-compact) .og-crossed-action-btn { padding-block: 0; min-height: 30px; font-size: 14px; }
+      :host(.og-compact) .og-add-view-item { height: 32px; font-size: 14px; padding: 4px 16px; }
+      :host(.og-compact) .og-add-view-item-name { font-size: 14px; }
+      :host(.og-compact) .og-add-view-on-list { font-size: 10px; }
+      :host(.og-compact) .og-add-input-wrapper input { height: 30px; font-size: 16px; }
       :host(.og-compact) .og-setting-option { font-size: 13px; padding: 8px 14px; }
       :host(.og-compact) .og-setting-list-option { font-size: 13px; padding: 8px 12px; }
     `;


### PR DESCRIPTION
Add compact mode CSS rules that were previously requiring card-mod overrides to achieve proper compact rendering:

- og-crossed-action-btn: reduce padding and min-height to 30px
- og-add-view-item: set height to 32px with compact font-size
- og-add-view-item-name: reduce font-size to 14px
- og-add-view-on-list: reduce font-size to 10px
- og-add-input-wrapper input: set height to 30px with 16px font

# Before & After

<img width="300" alt="image" src="https://github.com/user-attachments/assets/a26f09bc-cd8d-4711-92f1-4758c11a18ab" />
<img width="300" alt="image" src="https://github.com/user-attachments/assets/39f72a33-906f-4150-ac4e-d953546758d6" />

<img width="300" alt="image" src="https://github.com/user-attachments/assets/6049b412-0e42-4140-b45d-5acaadeb4d54" />
<img width="300" alt="image" src="https://github.com/user-attachments/assets/510e3f1d-bcbd-42e5-9b60-7a213152707c" />
