### PR TITLE
fix: 'On X list' not appearing until next poll cycle

### DIFF
--- a/custom_components/ourgroceries_kiosk/api.py
+++ b/custom_components/ourgroceries_kiosk/api.py
@@ -1,5 +1,6 @@
 """Async OurGroceries API client wrapper."""
 
+import asyncio
 import logging
 from functools import wraps
 from typing import Any, Callable, Coroutine
@@ -186,13 +187,13 @@ class OurGroceriesAPI:
         data = await client.get_my_lists()
         lists = data.get("shoppingLists", [])
 
+        valid = [(sl["id"], sl.get("name", "")) for sl in lists if sl.get("id")]
+        results = await asyncio.gather(
+            *(client.get_list_items(lid) for lid, _ in valid)
+        )
+
         item_map: dict[str, list[str]] = {}
-        for sl in lists:
-            list_id = sl.get("id", "")
-            list_name = sl.get("name", "")
-            if not list_id:
-                continue
-            list_data = await client.get_list_items(list_id)
+        for (_, list_name), list_data in zip(valid, results):
             items = list_data.get("list", {}).get("items", [])
             for item in items:
                 if item.get("crossedOff") or item.get("crossedOffAt"):

--- a/custom_components/ourgroceries_kiosk/frontend/ourgroceries-kiosk-card.js
+++ b/custom_components/ourgroceries_kiosk/frontend/ourgroceries-kiosk-card.js
@@ -301,7 +301,7 @@ class OurGroceriesKioskCard extends HTMLElement {
 
     // Load item-list-map in the background (expensive: fetches all lists' items)
     this._ws('ourgroceries_kiosk/get_item_list_map')
-      .then(map => { this._itemListMap = map || {}; })
+      .then(map => { this._itemListMap = map || {}; this._refreshAddViewItems(); })
       .catch(() => {});
   }
 
@@ -353,7 +353,7 @@ class OurGroceriesKioskCard extends HTMLElement {
 
       // Refresh item-list-map in the background (expensive call)
       this._ws('ourgroceries_kiosk/get_item_list_map')
-        .then(map => { this._itemListMap = map || {}; })
+        .then(map => { this._itemListMap = map || {}; this._refreshAddViewItems(); })
         .catch(() => {});
     } catch (err) {
       console.warn('OG Kiosk: poll failed', err);


### PR DESCRIPTION
Before this, it could take up to 30s to show which items were already added to a list. Now it's near instant.

<img width="295" height="132" alt="image" src="https://github.com/user-attachments/assets/cc8b0ccd-6d4a-473c-b12d-7e8e837f8bd5" />


The add-item view showed 'On X list' annotations with a significant delay because get_item_list_map fetched each list's items sequentially — one API roundtrip per list. With 5-10 lists this caused multi-second waits.

Backend (api.py):
- Replace sequential for-loop with asyncio.gather() to fetch all lists' items in parallel, reducing wall-clock time dramatically.

Frontend (ourgroceries-kiosk-card.js):
- Call _refreshAddViewItems() when the background item-list-map fetch completes, so 'On X list' annotations appear as soon as data arrives instead of waiting for the next poll cycle or view re-render.